### PR TITLE
parameterise the owner and group

### DIFF
--- a/puppet/api_skeleton/manifests/init.pp
+++ b/puppet/api_skeleton/manifests/init.pp
@@ -2,7 +2,9 @@
 class api_skeleton (
     $port = '9010',
     $host = '0.0.0.0',
-    $branch_or_revision = 'master'
+    $branch_or_revision = 'master',
+    $owner = 'vagrant',
+    $group = 'vagrant'
 ) {
   require ::standard_env
 
@@ -11,16 +13,16 @@ class api_skeleton (
     provider => git,
     source   => 'git://github.com/LandRegistry/charges-api-skeleton',
     revision => $branch_or_revision,
-    owner    => 'vagrant',
-    group    => 'vagrant',
+    owner    => $owner,
+    group    => $group,
     notify   => Service['api_skeleton'],
   }
 
   file { '/opt/api_skeleton/bin/run.sh':
     ensure  => 'file',
     mode    => '0755',
-    owner   => 'vagrant',
-    group   => 'vagrant',
+    owner   => $owner,
+    group   => $group,
     source  => "puppet:///modules/${module_name}/run.sh",
     require => Vcsrepo['/opt/api_skeleton'],
     notify  => Service['api_skeleton'],
@@ -29,8 +31,8 @@ class api_skeleton (
   file { '/etc/systemd/system/api_skeleton.service':
     ensure  => 'file',
     mode    => '0755',
-    owner   => 'vagrant',
-    group   => 'vagrant',
+    owner   => $owner,
+    group   => $group,
     content => template("${module_name}/service.systemd.erb"),
     notify  => [Exec['systemctl-daemon-reload'], Service['api_skeleton']],
   }
@@ -49,8 +51,8 @@ class api_skeleton (
     ensure  => 'file',
     mode    => '0755',
     content => template("${module_name}/nginx.conf.erb"),
-    owner   => 'vagrant',
-    group   => 'vagrant',
+    owner   => $owner,
+    group   => $group,
     notify  => Service['nginx'],
   }
 


### PR DESCRIPTION
Pulled in from [charges-borrower-frontend#320a899](https://github.com/LandRegistry/charges-borrower-frontend/commit/320a899b76924e5846b8d2b95a427489676d9a6d).

When running the app in vagrant we would prefer the vagrant user to run
the app, so that when we ssh in we can easily interact with the machine.

When running in the environment we should enable the apps to be run as
their own dedicated user (as old school ops-ers recommend).

To enable this I have parameterised the owner and group and defaulted
them back to vagrant so there is no functional difference.
