### PR TITLE
make env vars module specific

### DIFF
--- a/puppet/api_skeleton/templates/nginx.conf.erb
+++ b/puppet/api_skeleton/templates/nginx.conf.erb
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name <%= @subdomain %>;
+  server_name <%= @domain %>;
 
   location / {
     proxy_set_header X-Forwarded-Host $host;

--- a/puppet/api_skeleton/templates/run.sh.erb
+++ b/puppet/api_skeleton/templates/run.sh.erb
@@ -6,8 +6,8 @@ source ./.service_env/bin/activate
 
 pip3 install -r requirements.txt
 
-port="${API_SKELETON_GUNICORN_PORT:-8000}"
-host="${API_SKELETON_GUNICORN_HOST:-0.0.0.0}"
+port="${<%=@module_name.upcase%>_GUNICORN_PORT:-8000}"
+host="${<%=@module_name.upcase%>_GUNICORN_HOST:-0.0.0.0}"
 
 
 gunicorn -b $host:$port --pid /var/run/<%=@module_name%>/<%=@module_name%>.pid "app:create_manager().app"

--- a/puppet/api_skeleton/templates/service.systemd.erb
+++ b/puppet/api_skeleton/templates/service.systemd.erb
@@ -4,7 +4,7 @@ Description=Start the <%=@module_name%>
 [Service]
 PIDFile=/var/run/<%=@module_name%>/<%=@module_name%>.pid
 WorkingDirectory=/opt/<%=@module_name%>
-Environment='API_SKELETON_GUNICORN_PORT=<%=@port%>' 'API_SKELETON_GUNICORN_HOST=<%=@host%>'
+Environment='<%=@module_name.upcase%>_GUNICORN_PORT=<%=@port%>' '<%=@module_name.upcase%>_GUNICORN_HOST=<%=@host%>'
 Type=simple
 ExecStart=/bin/bash -c './bin/run.sh'
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
Since our puppet code can be run on the same box as other the Env vars
should be namespaced to make it less likely that they'll conflict. So
I've put the module name in uppercase infront of the ENV vars.
